### PR TITLE
Add sales tab for Apps Script demo

### DIFF
--- a/Index.html.txt
+++ b/Index.html.txt
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <style>
+    #salesFilters { margin-top: 10px; }
+    #salesData { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; }
+  </style>
+  <script>
+    function onLoad() {
+      document.getElementById('sellType').value = '4';
+      fetchSales();
+    }
+
+    function toggleFilters() {
+      var filters = document.getElementById('salesFilters');
+      filters.style.display = filters.style.display === 'block' ? 'none' : 'block';
+    }
+
+    function fetchSales() {
+      var sellType = document.getElementById('sellType').value;
+      var isReturn = document.getElementById('isReturn').checked;
+      document.getElementById('salesData').innerText = 'Loading...';
+      google.script.run.withSuccessHandler(function(data) {
+        document.getElementById('salesData').innerText = data;
+      }).getSalesData(sellType, isReturn);
+    }
+  </script>
+</head>
+<body onload="onLoad()">
+  <button onclick="toggleFilters();">Sales</button>
+  <div id="salesFilters" style="display:none;">
+    <label for="sellType">Тип продажи:</label>
+    <select id="sellType" onchange="fetchSales();">
+      <option value="1">1 - продажа за нал</option>
+      <option value="2">2 - продажа за безнал</option>
+      <option value="3">3 - продажа за внешний кредит</option>
+      <option value="4">4 - продажа за бонусы</option>
+      <option value="99">99 - неудачная продажа</option>
+    </select>
+    <label>
+      <input type="checkbox" id="isReturn" onchange="fetchSales();">
+      Возврат (IsReturn)
+    </label>
+  </div>
+  <div id="salesData"></div>
+</body>
+</html>

--- a/Index1.html.txt
+++ b/Index1.html.txt
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <style>
+    #salesFilters { margin-top: 10px; }
+    #salesData { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; }
+  </style>
+  <script>
+    function onLoad() {
+      document.getElementById('sellType').value = '4';
+      fetchSales();
+    }
+
+    function toggleFilters() {
+      var filters = document.getElementById('salesFilters');
+      filters.style.display = filters.style.display === 'block' ? 'none' : 'block';
+    }
+
+    function fetchSales() {
+      var sellType = document.getElementById('sellType').value;
+      var isReturn = document.getElementById('isReturn').checked;
+      document.getElementById('salesData').innerText = 'Loading...';
+      google.script.run.withSuccessHandler(function(data) {
+        document.getElementById('salesData').innerText = data;
+      }).getSalesData(sellType, isReturn);
+    }
+  </script>
+</head>
+<body onload="onLoad()">
+  <button onclick="toggleFilters();">Sales</button>
+  <div id="salesFilters" style="display:none;">
+    <label for="sellType">Тип продажи:</label>
+    <select id="sellType" onchange="fetchSales();">
+      <option value="1">1 - продажа за нал</option>
+      <option value="2">2 - продажа за безнал</option>
+      <option value="3">3 - продажа за внешний кредит</option>
+      <option value="4">4 - продажа за бонусы</option>
+      <option value="99">99 - неудачная продажа</option>
+    </select>
+    <label>
+      <input type="checkbox" id="isReturn" onchange="fetchSales();">
+      Возврат (IsReturn)
+    </label>
+  </div>
+  <div id="salesData"></div>
+</body>
+</html>

--- a/code.gs.txt
+++ b/code.gs.txt
@@ -1,0 +1,13 @@
+function doGet() {
+  return HtmlService.createHtmlOutputFromFile('Index');
+}
+
+function getSalesData(sellType, isReturn) {
+  var url = 'https://api.vendista.ru:99/sales/list?SellTypes=' + sellType +
+            '&token=fe38f8470367451f81228617';
+  if (isReturn) {
+    url += '&IsReturn=true';
+  }
+  var response = UrlFetchApp.fetch(url, {muteHttpExceptions: true});
+  return response.getContentText();
+}

--- a/code1.gs.txt
+++ b/code1.gs.txt
@@ -1,0 +1,13 @@
+function doGet() {
+  return HtmlService.createHtmlOutputFromFile('Index1');
+}
+
+function getSalesData(sellType, isReturn) {
+  var url = 'https://api.vendista.ru:99/sales/list?SellTypes=' + sellType +
+            '&token=fe38f8470367451f81228617';
+  if (isReturn) {
+    url += '&IsReturn=true';
+  }
+  var response = UrlFetchApp.fetch(url, {muteHttpExceptions: true});
+  return response.getContentText();
+}


### PR DESCRIPTION
## Summary
- add Apps Script server code for fetching sales list
- provide HTML interface with Sales tab, filters for SellType and IsReturn

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6870c1d040008327a3ca8b7387f5da71