### PR TITLE
Add unified index for multiple reports

### DIFF
--- a/CombinedCode.gs
+++ b/CombinedCode.gs
@@ -1,0 +1,25 @@
+/**
+ * Unified doGet to serve all three reports. Uses ?view=reports|machines|remote
+ * Default is a simple menu.
+ */
+function doGet(e) {
+  var view = (e && e.parameter && e.parameter.view) || 'menu';
+  if (view === 'reports') {
+    return HtmlService.createTemplateFromFile('Index').evaluate()
+      .setTitle('Отчёты Vendista');
+  } else if (view === 'machines') {
+    return HtmlService.createTemplateFromFile('Index2').evaluate()
+      .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+      .setTitle('Управление автоматами Vendista');
+  } else if (view === 'remote') {
+    return HtmlService.createTemplateFromFile('Index3').evaluate()
+      .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+      .setTitle('Управление товарами и журнал пакетов');
+  }
+  return HtmlService.createTemplateFromFile('MainMenu').evaluate()
+    .setTitle('Vendista Reports - Unified');
+}
+
+function include(filename) {
+  return HtmlService.createTemplateFromFile(filename).getRawContent();
+}

--- a/MainMenu.html
+++ b/MainMenu.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2rem; background:#f8f9fa; }
+    .menu { display:flex; flex-direction:column; gap:1rem; max-width:300px; margin:0 auto; }
+    .menu a { display:block; padding:0.8rem 1rem; background:#007bff; color:#fff; text-align:center; text-decoration:none; border-radius:4px; }
+    .menu a:hover { background:#0056b3; }
+  </style>
+</head>
+<body>
+  <h1>Vendista Unified Reports</h1>
+  <div class="menu">
+    <a href="?view=reports">Отчёты</a>
+    <a href="?view=machines">Управление автоматами</a>
+    <a href="?view=remote">Удалённый отчёт</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `CombinedCode.gs` with unified `doGet` router for the three existing reports
- add `MainMenu.html` landing page to navigate between reports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880b938f6e08327846f51451a7470e3